### PR TITLE
Skip performance test of mod-kb-ebsco-java module per RM API request

### DIFF
--- a/shared.groovy
+++ b/shared.groovy
@@ -182,6 +182,12 @@ def runJmeterTests(ctx) {
       echo "skip ${file}"
       continue;
     }
+
+  // skip kb-ebsco modules per rm api request
+    if (file.path.indexOf("kb-ebsco-java") > 0) {
+      echo "skip ${file}"
+      continue;
+    }
     def cmd = cmdTemplate + " -t ${file}"
     cmd += " -j jmeter_${BUILD_NUMBER}_${file.name}.log"
     echo "${cmd}"


### PR DESCRIPTION
Asked to disable mod-kb-ebsco-java performance tests per request from RM API team. Will disable when confirmed its ok.

Tests were currently limited to only run a single set of requests for 1 user (no loops)