### PR TITLE
Enable mod-kb-ebsco-java performance tests

### DIFF
--- a/shared.groovy
+++ b/shared.groovy
@@ -194,11 +194,6 @@ def runJmeterTests(ctx, platformOnly=false) {
       echo "skip ${file}"
       continue;
     }
-    // skip kb-ebsco modules per rm api request
-    if (file.path.indexOf("kb-ebsco-java") > 0) {
-      echo "skip ${file}"
-      continue;
-    }
     def cmd = cmdTemplate + " -t ${file}"
     cmd += " -j jmeter_${BUILD_NUMBER}_${file.name}.log"
     echo "${cmd}"


### PR DESCRIPTION
Per https://github.com/folio-org/folio-perf-test/pull/59 -- performance tests were temporarily disabled for mod-kb-ebsco-java module. This PR re-enables these tests as confirmed it is ok to do so.

Tests continue to be limited to only run a single set of requests for 1 user (no loops)