### PR TITLE
Use different build source for different perf builds

### DIFF
--- a/Jenkinsfile.folioci
+++ b/Jenkinsfile.folioci
@@ -10,7 +10,7 @@ properties([
     string(name: 'AwsSecurityGroups', defaultValue: 'sg-7ea9ef35', description: 'AWS VPC Security Groups to use'),
     string(name: 'AwsUsePublicIp', defaultValue: 'Yes', description: 'AWS EC2 has public IP or not'),
     string(name: 'MdRepo', defaultValue: 'http://folio-registry.aws.indexdata.com', description: 'Module descriptor repository'),
-    string(name: 'StableFolio', defaultValue: 'http://folio-snapshot-core.aws.indexdata.com', description: 'Use stable version of modules'),
+    string(name: 'StableFolio', defaultValue: 'http://folio-snapshot.aws.indexdata.com', description: 'Use stable version of modules'),
     text(name: 'FixedFolio', defaultValue: '', description: 'Paste install.json content here to use predefined module versions rather than pulling from stable FOLIO site'),
     string(name: 'SampleDataRepo', defaultValue: 'https://s3.amazonaws.com/folio-public-sample-data', description: 'Sample data repository'),
     string(name: 'SampleDataName', defaultValue: 'perf', description: 'Sample dataset name'),

--- a/cloudformation/folio.yml
+++ b/cloudformation/folio.yml
@@ -27,7 +27,7 @@ Parameters:
   InstanceTypeMods:
     Description: EC2 instance type for backend modules server
     Type: String
-    Default: m5.xlarge
+    Default: m5.2xlarge
   InstanceTypeDb:
     Description: EC2 instance type for database server
     Type: String


### PR DESCRIPTION
snapshot-core does not contain ekb modules so some tests will fail. Use snapshot for ci build and others use snapshot-core by default.