### PR TITLE
Skip mod-marccat

### DIFF
--- a/shared.groovy
+++ b/shared.groovy
@@ -301,7 +301,7 @@ def getMods(fixedMods, mdRepo) {
       continue
     }
     // skip mod-marccat for now due to database issue
-    if (!modName.startsWith("mod-marccat")) {
+    if (modName.startsWith("mod-marccat")) {
       continue
     }
     def modVer = group[0][2]

--- a/shared.groovy
+++ b/shared.groovy
@@ -300,6 +300,10 @@ def getMods(fixedMods, mdRepo) {
     if (!modName.startsWith("mod-") && !modName.startsWith("folio_")) {
       continue
     }
+    // skip mod-marccat for now due to database issue
+    if (!modName.startsWith("mod-marccat")) {
+      continue
+    }
     def modVer = group[0][2]
     if (!latestMods.containsKey(modName) || compareVersion(modVer, latestMods.get(modName))) {
       latestMods.put(modName, modVer)


### PR DESCRIPTION
The perf test env is broken because mod-marccat has a special database setup requirement. Skip this module for now so the perf test can continue.