### PR TITLE
Skip mod-kb-ebsco-java tests per request of HoldingsIQ Team

### DIFF
--- a/shared.groovy
+++ b/shared.groovy
@@ -207,6 +207,13 @@ def runJmeterTests(ctx, platformOnly=false) {
       echo "skip ${file}"
       continue;
     }
+
+    // skip kb-ebsco modules per rm api request
+    if (file.path.indexOf("kb-ebsco-java") > 0) {
+      echo "skip ${file}"
+      continue;
+    }
+
     def cmd = cmdTemplate + " -t ${file}"
     cmd += " -j jmeter_${BUILD_NUMBER}_${file.name}.log"
     echo "${cmd}"


### PR DESCRIPTION
As part of investigation of connections to HoldingsIQ -- we are temporarily disabling mod-kb-ebsco java performance tests 

This allows HoldingsIQ team to rule out performance tests as contributor to large number of connections