### PR TITLE
FOLIO-2513: Add jMeter test for an "isbn" search

### DIFF
--- a/Folio-Test-Plans/platform-workflow-performance/Platform-workflow-performance.jmx
+++ b/Folio-Test-Plans/platform-workflow-performance/Platform-workflow-performance.jmx
@@ -3075,6 +3075,135 @@ vars.put(&quot;idVal&quot;, curIds.instances[${__threadNum} - 1].id)</stringProp
         </ResultCollector>
         <hashTree/>
       </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group GET Instances by isbn" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">${__P(stressCount)}</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(stressThreads)}</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">${__P(stressRamp)}</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="GET query instances by isbn PreProcessor" enabled="true">
+          <stringProp name="scriptLanguage">groovy</stringProp>
+          <stringProp name="parameters"></stringProp>
+          <stringProp name="filename"></stringProp>
+          <stringProp name="cacheKey">true</stringProp>
+          <stringProp name="script">String[] isbns = [
+&apos;9789313160&apos;, &apos;9786278972&apos;, &apos;7955769655&apos;, &apos;9790262460&apos;, &apos;9788171202690&apos;,
+&apos;9788361723&apos;, &apos;6343987375&apos;, &apos;6481338936&apos;, &apos;6720862261&apos;, &apos;6949814386&apos;,
+&apos;7112207120&apos;, &apos;7361943685&apos;, &apos;3828325702&apos;, &apos;4067180361&apos;, &apos;4147658729&apos;,
+&apos;4231726023&apos;, &apos;4491508685&apos;, &apos;4689217619&apos;, &apos;4850917691&apos;, &apos;5091267369&apos;,
+&apos;5271984812&apos;, &apos;2222309777&apos;, &apos;2345686249&apos;, &apos;2468966734&apos;, &apos;1098308254&apos; ]
+Random r = new Random()
+String isbn = isbns[r.nextInt(isbns.length)]
+String isbnQuery = isbn
+int pos = r.nextInt(5)
+if (pos &gt; 0) {
+    isbnQuery = isbnQuery.substring(0, pos) + &apos;-&apos; + isbnQuery.substring(pos)
+}
+pos = r.nextInt(3)
+if (pos &gt; 0) {
+  isbnQuery = isbnQuery.substring(0, isbnQuery.size() - pos) + &apos;*&apos;
+}
+vars.put(&quot;isbnQuery&quot;, isbnQuery)
+vars.put(&quot;isbn&quot;, isbn)</stringProp>
+        </JSR223PreProcessor>
+        <hashTree/>
+        <HeaderManager guiclass="HeaderPanel" testclass="HeaderManager" testname="HTTP Header Manager" enabled="true">
+          <collectionProp name="HeaderManager.headers">
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">x-okapi-token</stringProp>
+              <stringProp name="Header.value">${__P(x-okapi-token)}</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">x-okapi-tenant</stringProp>
+              <stringProp name="Header.value">${tenant}</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">Accept</stringProp>
+              <stringProp name="Header.value">application/json, text/plain</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">content-type</stringProp>
+              <stringProp name="Header.value">application/json</stringProp>
+            </elementProp>
+          </collectionProp>
+        </HeaderManager>
+        <hashTree/>
+        <HTTPSamplerProxy guiclass="HttpTestSampleGui" testclass="HTTPSamplerProxy" testname="Perf - GET instance-storage/instances by isbn" enabled="true">
+          <elementProp name="HTTPsampler.Arguments" elementType="Arguments" guiclass="HTTPArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+            <collectionProp name="Arguments.arguments"/>
+          </elementProp>
+          <stringProp name="HTTPSampler.domain"></stringProp>
+          <stringProp name="HTTPSampler.port"></stringProp>
+          <stringProp name="HTTPSampler.protocol"></stringProp>
+          <stringProp name="HTTPSampler.contentEncoding"></stringProp>
+          <stringProp name="HTTPSampler.path">/instance-storage/instances?query=isbn=${isbnQuery}&amp;limit=30</stringProp>
+          <stringProp name="HTTPSampler.method">GET</stringProp>
+          <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
+          <boolProp name="HTTPSampler.auto_redirects">false</boolProp>
+          <boolProp name="HTTPSampler.use_keepalive">true</boolProp>
+          <boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
+          <stringProp name="HTTPSampler.embedded_url_re"></stringProp>
+          <stringProp name="HTTPSampler.connect_timeout"></stringProp>
+          <stringProp name="HTTPSampler.response_timeout">600000</stringProp>
+          <stringProp name="TestPlan.comments">limit&gt;18 is needed to suppress sequential scan for right truncation queries</stringProp>
+        </HTTPSamplerProxy>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="1212273104">${isbn}</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.custom_message"></stringProp>
+          <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+          <intProp name="Assertion.test_type">16</intProp>
+        </ResponseAssertion>
+        <hashTree/>
+        <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
       <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="FOLIO-1757 search instance by identifier type and value" enabled="true">
         <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
         <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">


### PR DESCRIPTION
Use limit=30 to prevent full table sequential scan for right truncation:

```
postgres=# explain SELECT jsonb,id FROM diku_mod_inventory_storage.instance
           WHERE to_tsvector('simple', normalize_isbns(jsonb->'identifiers')) @@ '9788171202690:*'::tsquery
           limit 18;
                                                              QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.00..580.32 rows=18 width=918)
   ->  Seq Scan on instance  (cost=0.00..1780092.74 rows=55214 width=918)
         Filter: (to_tsvector('simple'::regconfig, normalize_isbns((jsonb -> 'identifiers'::text))) @@ '''9788171202690'':*'::tsquery)
```

```
postgres=# explain SELECT jsonb,id FROM diku_mod_inventory_storage.instance
           WHERE to_tsvector('simple', normalize_isbns(jsonb->'identifiers')) @@ '9788171202690:*'::tsquery
           limit 19;
                                                                   QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=535.91..596.24 rows=19 width=918)
   ->  Bitmap Heap Scan on instance  (cost=535.91..175860.39 rows=55214 width=918)
         Recheck Cond: (to_tsvector('simple'::regconfig, normalize_isbns((jsonb -> 'identifiers'::text))) @@ '''9788171202690'':*'::tsquery)
         ->  Bitmap Index Scan on instance_isbn_idx_ft  (cost=0.00..522.10 rows=55214 width=0)
               Index Cond: (to_tsvector('simple'::regconfig, normalize_isbns((jsonb -> 'identifiers'::text))) @@ '''9788171202690'':*'::tsquery)
```