### PR TITLE
FOLIO-2575 Configure Jenkins job folio-integration

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -91,7 +91,7 @@ node('folio-perf-test') {
                   maven: 'maven3-jenkins-slave-all',
                   mavenSettingsConfig: 'folioci-maven-settings'
                 ) {
-                  sh "mvn test -DargLine='-Dkarate.env=${context.okapiIp}'"
+                  sh "mvn test -DargLine='-Dkarate.env=ec2-${context.okapiIp}.compute-1.amazonaws.com'"
                 }
               }
             }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -63,11 +63,10 @@ node('folio-perf-test') {
             sharedLib.bootstrapModules(context)
           }
 
-/*
           stage("Populate data") {
             sharedLib.populateData(context)
           }
-*/
+
           stage("Run integration tests") {
             node('jenkins-slave-all') {
               echo "Checkout folio-integration-tests"
@@ -99,6 +98,7 @@ node('folio-perf-test') {
           }
         } finally {
           stage("Tear down environment") {
+            sleep 60
             sharedLib.teardownEnv(context)
           }
         }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -100,7 +100,7 @@ node('folio-perf-test') {
           }
         } finally {
           stage("Tear down environment") {
-            sleep 60
+            sleep 300
             sharedLib.teardownEnv(context)
           }
         }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -68,32 +68,32 @@ node('folio-perf-test') {
             sharedLib.populateData(context)
           }
 */
-          stage("Checkout tests") {
-            echo "Do checkout folio-integration-tests"
-            checkout([
-              $class: 'GitSCM',
-              branches: [[name: '*/master']],
-              extensions: scm.extensions + [[$class: 'SubmoduleOption',
-                                             disableSubmodules: false,
-                                             parentCredentials: false,
-                                             recursiveSubmodules: true,
-                                             reference: '',
-                                             trackingSubmodules: false],
-                                            [$class: 'RelativeTargetDirectory',
-                                             relativeTargetDir: 'folio-integration-tests']],
-              userRemoteConfigs: [[url: 'https://github.com/folio-org/folio-integration-tests.git']]
-            ])
-          }
+          stage("Run integration tests") {
+            node('jenkins-slave-all') {
+              echo "Checkout folio-integration-tests"
+              checkout([
+                $class: 'GitSCM',
+                branches: [[name: '*/master']],
+                extensions: scm.extensions + [[$class: 'SubmoduleOption',
+                                               disableSubmodules: false,
+                                               parentCredentials: false,
+                                               recursiveSubmodules: true,
+                                               reference: '',
+                                               trackingSubmodules: false],
+                                              [$class: 'RelativeTargetDirectory',
+                                               relativeTargetDir: 'folio-integration-tests']],
+                userRemoteConfigs: [[url: 'https://github.com/folio-org/folio-integration-tests.git']]
+              ])
 
-          stage("Run tests") {
-            echo "Run all folio-integration-tests"
-            dir("${env.WORKSPACE}/folio-integration-tests") {
-              withMaven(
-                jdk: 'Amazon OpenJDK 8',
-                maven: 'Amazon Apache Maven 3.3.9',
-                mavenSettingsConfig: 'folioci-maven-settings'
-              ) {
-                sh "mvn --version"
+              echo "Run all folio-integration-tests"
+              dir("${env.WORKSPACE}/folio-integration-tests") {
+                withMaven(
+                  jdk: 'openjdk-8-jenkins-slave-all',
+                  maven: 'maven3-jenkins-slave-all',
+                  mavenSettingsConfig: 'folioci-maven-settings'
+                ) {
+                  sh "mvn --version"
+                }
               }
             }
           }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -93,6 +93,7 @@ node('folio-perf-test') {
                   mavenSettingsConfig: 'folioci-maven-settings'
                 ) {
                   sh "mvn --version"
+                  echo "okapiIp=${context.okapiIp}"
                 }
               }
             }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -1,0 +1,80 @@
+#!groovy
+
+properties([
+  parameters([
+    string(name: 'EnvName', defaultValue: 'folio-perf-test', description: 'Unique performance environment name'),
+    string(name: 'JenkinsAwsCredential', defaultValue: 'jenkins-aws', description: 'Jenkins credential to access AWS account'),
+    string(name: 'JenkinsEc2Credential', defaultValue: '11657186-f4d4-4099-ab72-2a32e023cced', description: 'Jenkins credential to SSH into AWS EC2'),
+    string(name: 'AwsKeyPair', defaultValue: 'aws-sling-dev', description: 'Aws KeyPair name for EC2 instances'),
+    string(name: 'AwsSubnet', defaultValue: 'subnet-4406021d', description: 'AWS Subnet to create EC2 instances'),
+    string(name: 'AwsSecurityGroups', defaultValue: 'sg-7ea9ef35', description: 'AWS VPC Security Groups to use'),
+    string(name: 'AwsUsePublicIp', defaultValue: 'Yes', description: 'AWS EC2 has public IP or not'),
+    string(name: 'MdRepo', defaultValue: 'http://folio-registry.aws.indexdata.com', description: 'Module descriptor repository'),
+    string(name: 'StableFolio', defaultValue: 'https://folio-snapshot.aws.indexdata.com', description: 'Use stable version of modules'),
+    string(name: 'FixedOkapi', defaultValue: '', description: 'Use specified version of Okapi'),
+    text(name: 'FixedMods', defaultValue: '', description: 'Paste install.json content here to use predefined module versions rather than pulling from stable FOLIO site'),
+    string(name: 'SampleDataRepo', defaultValue: 'https://s3.amazonaws.com/folio-public-sample-data', description: 'Sample data repository'),
+    string(name: 'SampleDataName', defaultValue: 'perf', description: 'Sample dataset name'),
+  ])
+])
+
+def sharedLib
+def context
+
+
+node('folio-perf-test') {
+  timeout(180) {
+
+    stage("Checkout") {
+      cleanWs()
+      checkout scm
+      sharedLib = load "shared.groovy"
+      context = sharedLib.getContext()
+    }
+
+    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "${context.awsKeyId}",
+      accessKeyVariable: 'AWS_ACCESS_KEY_ID', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+      usernamePassword(credentialsId: 'ebsco-rmapi-up', passwordVariable: 'RMAPI_PASSWORD',
+      usernameVariable: 'RMAPI_CUSTID')]) {
+      sshagent(credentials:["${context.sshKeyId}"]) {
+
+        try {
+          stage("Create Environment") {
+            sharedLib.createEnv(context)
+          }
+
+          stage("Wait for Environment") {
+          sharedLib.waitForEnv(context)
+          }
+
+          stage("Bootstrap DB") {
+            sharedLib.bootstrapDb(context)
+          }
+
+          stage("Bootstrap Okapi") {
+            sharedLib.bootstrapOkapi(context)
+          }
+
+          stage("Bootstrap modules") {
+            sharedLib.bootstrapModules(context)
+          }
+
+          stage("Populate data") {
+            sharedLib.populateData(context)
+          }
+
+          stage("Running JMeter tests") {
+            withEnv(['PATH+JMETER_PATH=/usr/local/apache-jmeter/bin']) {
+              echo "PATH is: $env.PATH"
+              sharedLib.runJmeterTests(context)
+            }
+          }
+        } finally {
+          stage("Tear down environment") {
+            sharedLib.teardownEnv(context)
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -73,7 +73,7 @@ node('folio-perf-test') {
               echo "Checkout folio-integration-tests"
               checkout([
                 $class: 'GitSCM',
-                branches: [[name: '*/master']],
+                branches: [[name: 'refs/heads/folio-2575-ci-integration-tests-2']],
                 extensions: scm.extensions + [[$class: 'SubmoduleOption',
                                                disableSubmodules: false,
                                                parentCredentials: false,

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -88,11 +88,23 @@ node('folio-perf-test') {
           stage("Run tests") {
             echo "Run all folio-integration-tests"
             dir("${env.WORKSPACE}/folio-integration-tests") {
+              sh "echo $PATH"
+              sh "echo $JAVA_HOME"
+              sh "java -version"
+              sh "echo $MAVEN_HOME"
+              sh "echo $M3_HOME"
+              sh "mvn --version"
               withMaven(
                 jdk: 'openjdk-8-jenkins-slave-all',
                 maven: 'maven3-jenkins-slave-all',
                 mavenSettingsConfig: 'folioci-maven-settings'
               ) {
+                sh "echo $PATH"
+                sh "echo $JAVA_HOME"
+                sh "java -version"
+                sh "echo $MAVEN_HOME"
+                sh "echo $M3_HOME"
+                sh "mvn --version"
                 sh 'mvn test'
               }
             }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -72,7 +72,7 @@ node('folio-perf-test') {
               echo "Checkout folio-integration-tests"
               checkout([
                 $class: 'GitSCM',
-                branches: [[name: 'refs/heads/folio-2575-ci-integration-tests']],
+                branches: [[name: '*/master']],
                 extensions: scm.extensions + [[$class: 'SubmoduleOption',
                                                disableSubmodules: false,
                                                parentCredentials: false,

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -93,7 +93,7 @@ node('folio-perf-test') {
                   mavenSettingsConfig: 'folioci-maven-settings'
                 ) {
                   sh "mvn --version"
-                  echo "okapiIp=${context.okapiIp}"
+                  sh "mvn test -DargLine='-Dkarate.env=${context.okapiIp}'"
                 }
               }
             }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -92,7 +92,8 @@ node('folio-perf-test') {
                   maven: 'maven3-jenkins-slave-all',
                   mavenSettingsConfig: 'folioci-maven-settings'
                 ) {
-                  sh "mvn test -DargLine='-Dkarate.env=${context.okapiIp}'"
+                  def okapiDns = "ec2-" + context.okapiIp.replaceAll(/\./, "-") + ".compute-1.amazonaws.com"
+                  sh "mvn test -DargLine='-Dkarate.env=${okapiDns}'"
                 }
               }
             }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -2,7 +2,8 @@
 
 // This Jenkinsfile.integration is used by the Jenkins job "folio-integration"
 // and using the FOLIO system built by the cloudformation configuration in this repository "folio-perf-test"
-// to then run the integration tests in the repository "folio-integration-tests".
+// to then run the integration tests in the repository "folio-integration-tests"
+// against the recent set of modules from "folio-snapshot"i reference environment.
 
 properties([
   parameters([
@@ -14,7 +15,7 @@ properties([
     string(name: 'AwsSecurityGroups', defaultValue: 'sg-7ea9ef35', description: 'AWS VPC Security Groups to use'),
     string(name: 'AwsUsePublicIp', defaultValue: 'Yes', description: 'AWS EC2 has public IP or not'),
     string(name: 'MdRepo', defaultValue: 'http://folio-registry.aws.indexdata.com', description: 'Module descriptor repository'),
-    string(name: 'StableFolio', defaultValue: 'https://folio-snapshot-core.aws.indexdata.com', description: 'Use stable version of modules'),
+    string(name: 'StableFolio', defaultValue: 'https://folio-snapshot.aws.indexdata.com', description: 'Use stable version of modules'),
     string(name: 'FixedOkapi', defaultValue: '', description: 'Use specified version of Okapi'),
     text(name: 'FixedMods', defaultValue: '', description: 'Paste install.json content here to use predefined module versions rather than pulling from stable FOLIO site'),
     string(name: 'SampleDataRepo', defaultValue: 'https://s3.amazonaws.com/folio-public-sample-data', description: 'Sample data repository'),

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -87,16 +87,14 @@ node('folio-perf-test') {
 
           stage("Verify Maven") {
             echo "Verify maven setup"
-            dir("${env.WORKSPACE}/folio-integration-tests") {
-              steps {
-                sh "echo PATH=$PATH"
-                sh "echo JAVA_HOME=$JAVA_HOME"
-                sh "echo MAVEN_HOME=$MAVEN_HOME"
-                sh "echo M3_HOME=$M3_HOME"
-                sh "java -version"
-                sh "mvn --version"
-              }
-            }
+            sh """
+              echo PATH=$PATH
+              echo JAVA_HOME=$JAVA_HOME
+              echo MAVEN_HOME=$MAVEN_HOME
+              echo M3_HOME=$M3_HOME
+              java -version
+              mvn --version
+            """
           }
 
           stage("Run tests") {
@@ -107,15 +105,15 @@ node('folio-perf-test') {
                 maven: 'maven3-jenkins-slave-all',
                 mavenSettingsConfig: 'folioci-maven-settings'
               ) {
-                steps {
-                  sh "echo PATH=$PATH"
-                  sh "echo JAVA_HOME=$JAVA_HOME"
-                  sh "echo MAVEN_HOME=$MAVEN_HOME"
-                  sh "echo M3_HOME=$M3_HOME"
-                  sh "java -version"
-                  sh "mvn --version"
-                  sh 'mvn test'
-                }
+                sh """
+                  echo PATH=$PATH
+                  echo JAVA_HOME=$JAVA_HOME
+                  echo MAVEN_HOME=$MAVEN_HOME
+                  echo M3_HOME=$M3_HOME
+                  java -version
+                  mvn --version
+                  mvn test
+                """
               }
             }
           }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -68,6 +68,35 @@ node('folio-perf-test') {
             sharedLib.populateData(context)
           }
 */
+          stage("Checkout tests") {
+            echo "Do checkout folio-integration-tests"
+            dir('integration') {
+              checkout([
+                $class: 'GitSCM',
+                branches: [[name: '*/master']],
+                extensions: scm.extensions + [[$class: 'SubmoduleOption',
+                                                       disableSubmodules: false,
+                                                       parentCredentials: false,
+                                                       recursiveSubmodules: true,
+                                                       reference: '',
+                                                       trackingSubmodules: false]],
+                userRemoteConfigs: [[url: 'https://github.com/folio-org/folio-integration-tests.git']]
+              ])
+            }
+          }
+
+          stage("Run tests") {
+            echo "Run all folio-integration-tests"
+            withMaven(
+              jdk: 'openjdk-8-jenkins-slave-all',
+              maven: 'maven3-jenkins-slave-all',
+              mavenSettingsConfig: 'folioci-maven-settings'
+            ) {
+              dir ('integration') {
+                sh 'mvn test'
+              }
+            }
+          }
         } finally {
           stage("Tear down environment") {
             sharedLib.teardownEnv(context)

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -89,8 +89,8 @@ node('folio-perf-test') {
             echo "Run all folio-integration-tests"
             dir("${env.WORKSPACE}/folio-integration-tests") {
               withMaven(
-                jdk: 'openjdk-8-jenkins-slave-all',
-                maven: 'maven3-jenkins-slave-all',
+                jdk: 'Amazon OpenJDK 8',
+                maven: 'Amazon Apache Maven 3.3.9',
                 mavenSettingsConfig: 'folioci-maven-settings'
               ) {
                 sh "mvn --version"

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -73,7 +73,7 @@ node('folio-perf-test') {
               echo "Checkout folio-integration-tests"
               checkout([
                 $class: 'GitSCM',
-                branches: [[name: 'refs/heads/folio-2575-ci-integration-tests-2']],
+                branches: [[name: '*/master']],
                 extensions: scm.extensions + [[$class: 'SubmoduleOption',
                                                disableSubmodules: false,
                                                parentCredentials: false,

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -1,8 +1,12 @@
 #!groovy
 
+// This Jenkinsfile.integration is used by the Jenkins job "folio-integration"
+// and using the FOLIO system built by the cloudformation configuration in this repository "folio-perf-test"
+// to then run the integration tests in the repository "folio-integration-tests".
+
 properties([
   parameters([
-    string(name: 'EnvName', defaultValue: 'folio-perf-test', description: 'Unique performance environment name'),
+    string(name: 'EnvName', defaultValue: 'folio-integration', description: 'Unique environment name'),
     string(name: 'JenkinsAwsCredential', defaultValue: 'jenkins-aws', description: 'Jenkins credential to access AWS account'),
     string(name: 'JenkinsEc2Credential', defaultValue: '11657186-f4d4-4099-ab72-2a32e023cced', description: 'Jenkins credential to SSH into AWS EC2'),
     string(name: 'AwsKeyPair', defaultValue: 'aws-sling-dev', description: 'Aws KeyPair name for EC2 instances'),
@@ -59,16 +63,11 @@ node('folio-perf-test') {
             sharedLib.bootstrapModules(context)
           }
 
+/*
           stage("Populate data") {
             sharedLib.populateData(context)
           }
-
-          stage("Running JMeter tests") {
-            withEnv(['PATH+JMETER_PATH=/usr/local/apache-jmeter/bin']) {
-              echo "PATH is: $env.PATH"
-              sharedLib.runJmeterTests(context)
-            }
-          }
+*/
         } finally {
           stage("Tear down environment") {
             sharedLib.teardownEnv(context)

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -73,7 +73,7 @@ node('folio-perf-test') {
               echo "Checkout folio-integration-tests"
               checkout([
                 $class: 'GitSCM',
-                branches: [[name: '*/master']],
+                branches: [[name: 'refs/heads/folio-2575-ci-integration-tests']],
                 extensions: scm.extensions + [[$class: 'SubmoduleOption',
                                                disableSubmodules: false,
                                                parentCredentials: false,

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -3,7 +3,7 @@
 // This Jenkinsfile.integration is used by the Jenkins job "folio-integration"
 // and using the FOLIO system built by the cloudformation configuration in this repository "folio-perf-test"
 // to then run the integration tests in the repository "folio-integration-tests"
-// against the recent set of modules from "folio-snapshot"i reference environment.
+// against the recent set of modules from "folio-snapshot" reference environment.
 
 properties([
   parameters([
@@ -100,7 +100,7 @@ node('folio-perf-test') {
           }
         } finally {
           stage("Tear down environment") {
-            sleep 300
+            sleep 60
             sharedLib.teardownEnv(context)
           }
         }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -85,18 +85,6 @@ node('folio-perf-test') {
             ])
           }
 
-          stage("Verify Maven") {
-            echo "Verify maven setup"
-            sh """
-              echo PATH=$PATH
-              echo JAVA_HOME=$JAVA_HOME
-              echo MAVEN_HOME=$MAVEN_HOME
-              echo M3_HOME=$M3_HOME
-              java -version
-              mvn --version
-            """
-          }
-
           stage("Run tests") {
             echo "Run all folio-integration-tests"
             dir("${env.WORKSPACE}/folio-integration-tests") {
@@ -105,15 +93,7 @@ node('folio-perf-test') {
                 maven: 'maven3-jenkins-slave-all',
                 mavenSettingsConfig: 'folioci-maven-settings'
               ) {
-                sh """
-                  echo PATH=$PATH
-                  echo JAVA_HOME=$JAVA_HOME
-                  echo MAVEN_HOME=$MAVEN_HOME
-                  echo M3_HOME=$M3_HOME
-                  java -version
-                  mvn --version
-                  mvn test
-                """
+                sh "mvn --version"
               }
             }
           }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -92,7 +92,7 @@ node('folio-perf-test') {
                   maven: 'maven3-jenkins-slave-all',
                   mavenSettingsConfig: 'folioci-maven-settings'
                 ) {
-                  sh "mvn test -DargLine='-Dkarate.env=ec2-${context.okapiIp}.compute-1.amazonaws.com'"
+                  sh "mvn test -DargLine='-Dkarate.env=${context.okapiIp}'"
                 }
               }
             }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -70,29 +70,29 @@ node('folio-perf-test') {
 */
           stage("Checkout tests") {
             echo "Do checkout folio-integration-tests"
-            dir('integration') {
-              checkout([
-                $class: 'GitSCM',
-                branches: [[name: '*/master']],
-                extensions: scm.extensions + [[$class: 'SubmoduleOption',
-                                                       disableSubmodules: false,
-                                                       parentCredentials: false,
-                                                       recursiveSubmodules: true,
-                                                       reference: '',
-                                                       trackingSubmodules: false]],
-                userRemoteConfigs: [[url: 'https://github.com/folio-org/folio-integration-tests.git']]
-              ])
-            }
+            checkout([
+              $class: 'GitSCM',
+              branches: [[name: '*/master']],
+              extensions: scm.extensions + [[$class: 'SubmoduleOption',
+                                             disableSubmodules: false,
+                                             parentCredentials: false,
+                                             recursiveSubmodules: true,
+                                             reference: '',
+                                             trackingSubmodules: false],
+                                            [$class: 'RelativeTargetDirectory',
+                                             relativeTargetDir: 'folio-integration-tests']],
+              userRemoteConfigs: [[url: 'https://github.com/folio-org/folio-integration-tests.git']]
+            ])
           }
 
           stage("Run tests") {
             echo "Run all folio-integration-tests"
-            withMaven(
-              jdk: 'openjdk-8-jenkins-slave-all',
-              maven: 'maven3-jenkins-slave-all',
-              mavenSettingsConfig: 'folioci-maven-settings'
-            ) {
-              dir ('integration') {
+            dir("${env.WORKSPACE}/folio-integration-tests") {
+              withMaven(
+                jdk: 'openjdk-8-jenkins-slave-all',
+                maven: 'maven3-jenkins-slave-all',
+                mavenSettingsConfig: 'folioci-maven-settings'
+              ) {
                 sh 'mvn test'
               }
             }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -14,7 +14,7 @@ properties([
     string(name: 'AwsSecurityGroups', defaultValue: 'sg-7ea9ef35', description: 'AWS VPC Security Groups to use'),
     string(name: 'AwsUsePublicIp', defaultValue: 'Yes', description: 'AWS EC2 has public IP or not'),
     string(name: 'MdRepo', defaultValue: 'http://folio-registry.aws.indexdata.com', description: 'Module descriptor repository'),
-    string(name: 'StableFolio', defaultValue: 'https://folio-snapshot.aws.indexdata.com', description: 'Use stable version of modules'),
+    string(name: 'StableFolio', defaultValue: 'https://folio-snapshot-core.aws.indexdata.com', description: 'Use stable version of modules'),
     string(name: 'FixedOkapi', defaultValue: '', description: 'Use specified version of Okapi'),
     text(name: 'FixedMods', defaultValue: '', description: 'Paste install.json content here to use predefined module versions rather than pulling from stable FOLIO site'),
     string(name: 'SampleDataRepo', defaultValue: 'https://s3.amazonaws.com/folio-public-sample-data', description: 'Sample data repository'),
@@ -92,7 +92,6 @@ node('folio-perf-test') {
                   maven: 'maven3-jenkins-slave-all',
                   mavenSettingsConfig: 'folioci-maven-settings'
                 ) {
-                  sh "mvn --version"
                   sh "mvn test -DargLine='-Dkarate.env=${context.okapiIp}'"
                 }
               }

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -85,27 +85,37 @@ node('folio-perf-test') {
             ])
           }
 
+          stage("Verify Maven") {
+            echo "Verify maven setup"
+            dir("${env.WORKSPACE}/folio-integration-tests") {
+              steps {
+                sh "echo PATH=$PATH"
+                sh "echo JAVA_HOME=$JAVA_HOME"
+                sh "echo MAVEN_HOME=$MAVEN_HOME"
+                sh "echo M3_HOME=$M3_HOME"
+                sh "java -version"
+                sh "mvn --version"
+              }
+            }
+          }
+
           stage("Run tests") {
             echo "Run all folio-integration-tests"
             dir("${env.WORKSPACE}/folio-integration-tests") {
-              sh "echo $PATH"
-              sh "echo $JAVA_HOME"
-              sh "java -version"
-              sh "echo $MAVEN_HOME"
-              sh "echo $M3_HOME"
-              sh "mvn --version"
               withMaven(
                 jdk: 'openjdk-8-jenkins-slave-all',
                 maven: 'maven3-jenkins-slave-all',
                 mavenSettingsConfig: 'folioci-maven-settings'
               ) {
-                sh "echo $PATH"
-                sh "echo $JAVA_HOME"
-                sh "java -version"
-                sh "echo $MAVEN_HOME"
-                sh "echo $M3_HOME"
-                sh "mvn --version"
-                sh 'mvn test'
+                steps {
+                  sh "echo PATH=$PATH"
+                  sh "echo JAVA_HOME=$JAVA_HOME"
+                  sh "echo MAVEN_HOME=$MAVEN_HOME"
+                  sh "echo M3_HOME=$M3_HOME"
+                  sh "java -version"
+                  sh "mvn --version"
+                  sh 'mvn test'
+                }
               }
             }
           }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 folio-perf-test - Jenkins pipeline to test FOLIO performance
 =================================
 
-Copyright (C) 2018 The Open Library Foundation
+Copyright (C) 2018-2020 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
The Jenkinsfile.integration is used by the Jenkins job "folio-integration" and using the FOLIO system built by the cloudformation configuration in this repository "folio-perf-test", to then run the integration tests in the repository "folio-integration-tests" against the recent set of modules from "folio-snapshot" reference environment.