### PR TITLE
Fix for regex issue with edge-sip2

### DIFF
--- a/shared.groovy
+++ b/shared.groovy
@@ -316,6 +316,11 @@ def getMods(fixedMods, mdRepo) {
   }
   def latestMods = [:]
   for (mod in mods) {
+    // skip edge-sip2 for now due to regex issue
+    if (mod.id.startsWith("edge-sip2")) {
+      continue
+    }
+    
     def group = (mod.id =~ /(^\D+)-(\d+.*$)/)
     def modName = group[0][1]
     // only select backend (mod-) and frontend (folio-) modules


### PR DESCRIPTION
pipeline doesn't parse 'edge-sip2' name and version in current implementation of regex rules